### PR TITLE
Issue#004

### DIFF
--- a/src/js/components/game.js
+++ b/src/js/components/game.js
@@ -30,14 +30,7 @@ export default class Game {
         this.blackKingChecked = false;
         this.gameHistory = new Array();
         this.currentState = new GameStateProvider;
-        this.setStateParams = [this.gameTime,
-            this.whiteSetOfPieces,
-            this.blackSetOfPieces,
-            this.whiteTime, this.blackTime,
-            this.turn, this.capturedWhite, this.capturedBlack,
-            this.currentBoard,
-            this.choosenPieceID, this.listOfSquares,
-            this.whiteKingChecked, this.blackKingChecked]
+        this.setStateParams = new Array();
 
         this.makeSetOfPieces();
         this.undoMove();
@@ -45,11 +38,11 @@ export default class Game {
         this.renderBoard();
         this.listOfSquares = document.querySelectorAll('.square');
         this.selectAndMovePiece();
+        this.copyCurrState();
         this.setState(...this.setStateParams);
     }
 
     setState(
-        gameTime,
         whiteSetOfPieces,
         blackSetOfPieces,
         whiteTime, blackTime,
@@ -58,49 +51,57 @@ export default class Game {
         choosenPieceID, listOfSquares,
         whiteKingChecked, blackKingChecked
     ) {
-        this.currentState.gameTime = gameTime,
-        this.currentState.whiteSetOfPieces = cloneDeep(whiteSetOfPieces),
-        this.currentState.blackSetOfPieces = cloneDeep(blackSetOfPieces),
+        this.currentState.whiteSetOfPieces = whiteSetOfPieces,
+        this.currentState.blackSetOfPieces = blackSetOfPieces,
         this.currentState.whiteTime = whiteTime,
         this.currentState.blackTime = blackTime,
         this.currentState.turn = turn,
-        this.currentState.capturedWhite = cloneDeep(capturedWhite),
-        this.currentState.capturedBlack = cloneDeep(capturedBlack),
-        this.currentState.currentBoard = cloneDeep(currentBoard),
+        this.currentState.capturedWhite = capturedWhite,
+        this.currentState.capturedBlack = capturedBlack,
+        this.currentState.currentBoard = currentBoard,
         this.currentState.choosenPieceID = choosenPieceID,
-        this.currentState.listOfSquares = cloneDeep(listOfSquares),
+        this.currentState.listOfSquares = listOfSquares,
         this.currentState.whiteKingChecked = whiteKingChecked,
         this.currentState.blackKingChecked = blackKingChecked
     }
+    copyCurrState(){
+        // return array of copied variables from constructor representing the current game state:
+        return this.setStateParams = [
+            cloneDeep(this.whiteSetOfPieces),
+            cloneDeep(this.blackSetOfPieces),
+            this.whiteTime, this.blackTime,
+            this.turn, cloneDeep(this.capturedWhite), cloneDeep(this.capturedBlack),
+            cloneDeep(this.currentBoard),
+            this.choosenPieceID, cloneDeep(this.listOfSquares),
+            this.whiteKingChecked, this.blackKingChecked
+        ]
+    }
     updateHistory() {
+        // gameHistory get a new element which represents the recent state of the game taken thanks to GameStateProvider
         this.gameHistory.push(this.currentState.saveMemento());
-        console.log(this.gameHistory);
-        console.log(this.whiteSetOfPieces);
     }
     undoMove() {
-        document.querySelector('.undo').addEventListener('click', () => {
-            if (this.gameHistory.length < 1) return;
-            console.log(this.gameHistory);
-            this.currentState.restoreMemento(this.gameHistory.pop());
-            (() => (
-                this.gameTime = this.currentState.gameTime,
-                this.whiteSetOfPieces = cloneDeep(this.currentState.whiteSetOfPieces),
-                this.blackSetOfPieces = cloneDeep(this.currentState.blackSetOfPieces),
-                this.whiteTime = this.currentState.whiteTime,
-                this.blackTime = this.currentState.blackTime,
-                this.turn = this.currentState.turn,
-                this.capturedWhite = cloneDeep(this.currentState.capturedWhite),
-                this.capturedBlack = cloneDeep(this.currentState.capturedBlack),
-                this.currentBoard = cloneDeep(this.currentState.currentBoard),
-                this.choosenPieceID = this.currentState.choosenPieceID,
-                this.listOfSquares = cloneDeep(this.currentState.listOfSquares),
-                this.whiteKingChecked = this.currentState.whiteKingChecked,
-                this.blackKingChecked = this.currentState.blackKingChecked
-            ))();
-            this.setState(...this.setStateParams);
-            this.renderBoard();
-            this.renderPanel();
-        })
+        // return when the history is empty (the very first stage of the game):
+        if (this.gameHistory.length < 1) return;
+        // restore memento update this.currentState by taking the last item from the gameHistory:
+        this.currentState.restoreMemento(this.gameHistory.pop());
+        // block below update constructor variables using the restored this.currentState:
+            this.whiteSetOfPieces = cloneDeep(this.currentState.whiteSetOfPieces)
+            this.blackSetOfPieces = cloneDeep(this.currentState.blackSetOfPieces)
+            this.whiteTime = this.currentState.whiteTime
+            this.blackTime = this.currentState.blackTime
+            this.turn = this.currentState.turn
+            this.capturedWhite = cloneDeep(this.currentState.capturedWhite)
+            this.capturedBlack = cloneDeep(this.currentState.capturedBlack)
+            this.currentBoard = cloneDeep(this.currentState.currentBoard)
+            this.choosenPieceID = this.currentState.choosenPieceID
+            this.listOfSquares = cloneDeep(this.currentState.listOfSquares)
+            this.whiteKingChecked = this.currentState.whiteKingChecked
+            this.blackKingChecked = this.currentState.blackKingChecked
+            
+        // render board and panel with restored data:
+        this.renderBoard();
+        this.renderPanel();
     }
     evaluatePieceProperties(id, target, board, [targX, targY], [currX, currY]) {
         // if choosen piece id is equal to value of default king position and target square is equal to value of default castling move for king, then execute castling() method:
@@ -174,7 +175,8 @@ export default class Game {
                     this.renderPanel();
                     // reset variable:
                     this.choosenPieceID = null;
-                    // save current state:
+                    //copy and save current state:
+                    this.copyCurrState();
                     this.setState(...this.setStateParams);
                     return;
                 } else {
@@ -386,3 +388,4 @@ export default class Game {
         this.turn = this.turn === 'white' ? 'black' : 'white';
     }
 }
+

--- a/src/js/components/game.js
+++ b/src/js/components/game.js
@@ -74,10 +74,13 @@ export default class Game {
     }
     updateHistory() {
         this.gameHistory.push(this.currentState.saveMemento());
+        console.log(this.gameHistory);
+        console.log(this.whiteSetOfPieces);
     }
     undoMove() {
         document.querySelector('.undo').addEventListener('click', () => {
             if (this.gameHistory.length < 1) return;
+            console.log(this.gameHistory);
             this.currentState.restoreMemento(this.gameHistory.pop());
             (() => (
                 this.gameTime = this.currentState.gameTime,

--- a/src/js/components/gamestate.js
+++ b/src/js/components/gamestate.js
@@ -1,6 +1,5 @@
 export default class GameState {
     constructor(
-        gameTime,
         whiteSetOfPieces,
         blackSetOfPieces,
         whiteTime, blackTime,
@@ -8,7 +7,6 @@ export default class GameState {
         currentBoard,
         choosenPieceID, listOfSquares,
         whiteKingChecked, blackKingChecked ){
-        this.gameTime = gameTime,
         this.whiteSetOfPieces = whiteSetOfPieces,
         this.blackSetOfPieces = blackSetOfPieces,
         this.whiteTime = whiteTime,

--- a/src/js/components/gamestateprovider.js
+++ b/src/js/components/gamestateprovider.js
@@ -3,7 +3,6 @@ import GameState from './gamestate.js';
 export default class GameStateProvider {
     saveMemento() {
         return new GameState(
-            this.gameTime,
             this.whiteSetOfPieces,
             this.blackSetOfPieces,
             this.whiteTime,
@@ -19,7 +18,6 @@ export default class GameStateProvider {
         )
     }
     restoreMemento(memento) {
-        this.gameTime = memento.gameTime,
         this.whiteSetOfPieces = memento.whiteSetOfPieces,
         this.blackSetOfPieces = memento.blackSetOfPieces,
         this.whiteTime = memento.whiteTime,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,7 @@
 import Game from './components/game.js';
 
-document.querySelector('.refresh').addEventListener('click', () => new Game(300));
+let newGame;
+
+document.querySelector('.refresh').addEventListener('click', () => newGame = new Game(300));
+
+document.querySelector('.undo').addEventListener('click', () => newGame.undoMove());


### PR DESCRIPTION
### Issue #004

### What has changed:
1. this.setStateParam is invoked now by the method provided in the class body:
> parameters are copied with cloneDeep in helper method copyCurrState
> that make sure the parameters are accurate
2. method undoMove:
> addeventlistener taken out the class
> self-invoked function removed
> setState is duplicate here, the this.currentState.restoreMemento is updating the current state
3.  method selectAndMovePiece:
> add copyCurrState before invoking method setState - this makes sure the accurate state is passed in

### What reviewers should know:
The problem with the history was that the setStateParams was invoked once, in the beginning, and each time methods undoMove or selectAndMovePiece were invoking this.setState, the same copy of some state values was passed in. That caused behaviour like the same turn or time value in the game's history. I have also clean up the method undoMove and removed this.gameTime variable, is not needed anymore. 

